### PR TITLE
Remove getFdName

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ You can use [gopkg.in](http://labix.org/gopkg.in):
 If you want to use the library in production project, please use vendoring,
 because i can not ensure backward compatibility before release v1.0.
 
-## Build
-
-Please keep in mind that if you want to use cross-compilation you should set `CGO_ENABLED` environment variable to `1` because cgo is turned off by default when cross-compiling.
-
 ## Examples
 
 * [Simple](examples/cmd/gd-simple/)

--- a/daemon.go
+++ b/daemon.go
@@ -11,6 +11,7 @@ var errNotSupported = errors.New("daemon: Non-POSIX OS is not supported")
 const (
 	MARK_NAME  = "_GO_DAEMON"
 	MARK_VALUE = "1"
+	MARK_PID   = "_GO_DAEMON_PID"
 )
 
 // Default file permissions for log and pid files.

--- a/lock_file.go
+++ b/lock_file.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"syscall"
 )
 
 var (
@@ -106,19 +105,5 @@ func (file *LockFile) Remove() error {
 		return err
 	}
 
-	// TODO(yar): keep filename?
-	name, err := GetFdName(file.Fd())
-	if err != nil {
-		return err
-	}
-
-	err = syscall.Unlink(name)
-	return err
-}
-
-// GetFdName returns file name for given descriptor.
-//
-// BUG(yar): GetFdName returns an error for some *nix platforms when full name length of the file is greater than 0x1000.
-func GetFdName(fd uintptr) (name string, err error) {
-	return getFdName(fd)
+	return os.Remove(file.Name())
 }

--- a/lock_file_darwin.go
+++ b/lock_file_darwin.go
@@ -4,13 +4,7 @@ package daemon
 
 import (
 	"syscall"
-	"unsafe"
 )
-
-import "C"
-
-// darwin's MAXPATHLEN
-const maxpathlen = 1024
 
 func lockFile(fd uintptr) error {
 	err := syscall.Flock(int(fd), syscall.LOCK_EX|syscall.LOCK_NB)
@@ -26,13 +20,4 @@ func unlockFile(fd uintptr) error {
 		err = ErrWouldBlock
 	}
 	return err
-}
-
-func getFdName(fd uintptr) (name string, err error) {
-	buf := make([]C.char, maxpathlen+1)
-	_, _, errno := syscall.Syscall(syscall.SYS_FCNTL, fd, syscall.F_GETPATH, uintptr(unsafe.Pointer(&buf[0])))
-	if errno == 0 {
-		return C.GoString(&buf[0]), nil
-	}
-	return "", errno
 }

--- a/lock_file_stub.go
+++ b/lock_file_stub.go
@@ -9,7 +9,3 @@ func lockFile(fd uintptr) error {
 func unlockFile(fd uintptr) error {
 	return errNotSupported
 }
-
-func getFdName(fd uintptr) (name string, err error) {
-	return "", errNotSupported
-}

--- a/lock_file_test.go
+++ b/lock_file_test.go
@@ -53,22 +53,6 @@ func TestNewLockFile(test *testing.T) {
 	}
 }
 
-func TestGetFdName(test *testing.T) {
-	name, err := GetFdName(0)
-	if err != nil {
-		test.Error(err)
-	} else {
-		if name != "/dev/null" {
-			test.Errorf("Filename of fd 0: `%s'", name)
-		}
-	}
-
-	name, err = GetFdName(1011)
-	if err == nil {
-		test.Errorf("GetFdName(): Error was not detected on invalid fd, name: `%s'", name)
-	}
-}
-
 func TestReadPid(test *testing.T) {
 	lock, err := CreatePidFile(filename, fileperm)
 	if err != nil {

--- a/lock_file_unix.go
+++ b/lock_file_unix.go
@@ -22,19 +22,3 @@ func unlockFile(fd uintptr) error {
 	}
 	return err
 }
-
-const pathMax = 0x1000
-
-func getFdName(fd uintptr) (name string, err error) {
-	path := fmt.Sprintf("/proc/self/fd/%d", int(fd))
-	// We use predefined pathMax const because /proc directory contains special files
-	// so that unable to get correct size of pseudo-symlink through lstat.
-	// please see notes and example for readlink syscall:
-	// http://man7.org/linux/man-pages/man2/readlink.2.html#NOTES
-	buf := make([]byte, pathMax)
-	var n int
-	if n, err = syscall.Readlink(path, buf); err == nil {
-		name = string(buf[:n])
-	}
-	return
-}


### PR DESCRIPTION
https://github.com/sevlyar/go-daemon/pull/1

getFdNameを削除して、CGOを依存から外す。

workDir を変更すると正しく動かなくなる。